### PR TITLE
Some fixes regarding event-broker/dispatcher

### DIFF
--- a/src/dispatcher.coffee
+++ b/src/dispatcher.coffee
@@ -86,9 +86,11 @@ module.exports = new class Dispatcher
 	# @private
 	###
 	finalizeDispatching = () ->
-		@callFinalizers()
-		currentAction = null
-		dispatching = no
+		try
+			@callFinalizers()
+		finally
+			currentAction = null
+			dispatching = no
 
 	###
     # Calls the action handler on a store with the current action and payload.

--- a/src/event-broker.coffee
+++ b/src/event-broker.coffee
@@ -6,6 +6,8 @@ module.exports = () ->
 	_listeners = []
 	_immediateListeners = []
 	shouldTrigger = no
+	removedListenerSinceLastDispatch = []
+	removedImmediateListenerSinceLastDispatch = []
 
 	EventBroker = () ->
 		EventBroker.dispatch()
@@ -19,8 +21,11 @@ module.exports = () ->
 			listeners = []
 			unless context?
 				console.error "Warning: You should supply context to changed.remove(...) as a second parameter. Not doing so will remove listeners from all instances of your component."
-			for listener, index in _listeners when listener.fn isnt fn and listener.context isnt context
-				listeners.push listener
+			for listener, index in _listeners
+				if listener.fn isnt fn and listener.context isnt context
+					listeners.push listener
+				else
+					removedListenerSinceLastDispatch.push listener
 			_listeners = listeners
 
 	EventBroker.addImmediate = (fn, context) ->
@@ -32,8 +37,11 @@ module.exports = () ->
 			listeners = []
 			unless context?
 				console.error "Warning: You should supply context to changed.removeImmediate(...) as a second parameter. Not doing so will remove listeners from all instances of your component."
-			for listener, index in _immediateListeners when listener.fn isnt fn and listener.context isnt context
-				listeners.push listener
+			for listener, index in _immediateListeners
+				if listener.fn isnt fn and listener.context isnt context
+					listeners.push listener
+				else
+					removedImmediateListenerSinceLastDispatch.push listener
 			_immediateListeners = listeners
 
 	EventBroker.dispatch = (args...) ->
@@ -47,18 +55,29 @@ module.exports = () ->
 			if dispatcher.isDispatching()
 				shouldTrigger = yes
 			else
-				for listener in _listeners
+				listeners = _listeners.slice 0
+				removedListenerSinceLastDispatch = []
+				# Allow removing listeners while looping through them
+				# This means that removed listeners that has not yet been called
+				# during this dispatch won't get called.
+				# Also it means newly added dispatchers during the dispatching
+				# won't ever get called
+				for listener in listeners when listener not in removedListenerSinceLastDispatch
 					if listener.context? then listener.fn.apply(listener.context) else listener.fn()
 			# Make sure all immediate listeners are called.
 			EventBroker.dispatchImmediate()
 
 	EventBroker.dispatchImmediate = (args...) ->
-			for listener in _immediateListeners
-				if listener.context? then listener.fn.apply(listener.context, args) else listener.fn()
+		listeners = _immediateListeners.slice 0
+		removedImmediateListenerSinceLastDispatch = []
+		for listener in listeners when listener not in removedImmediateListenerSinceLastDispatch
+			if listener.context? then listener.fn.apply(listener.context, args) else listener.fn()
 
 	dispatcher.onFinalize () ->
 		if shouldTrigger is yes
-			for listener in _listeners
+			listeners = _listeners.slice 0
+			removedListenerSinceLastDispatch = []
+			for listener in listeners when listener not in removedListenerSinceLastDispatch
 				if listener.context? then listener.fn.apply(listener.context) else listener.fn()
 		shouldTrigger = no
 

--- a/test/dispatcher.coffee
+++ b/test/dispatcher.coffee
@@ -58,6 +58,24 @@ describe 'Dispatcher', () ->
 		dispatcher.dispatch actionInstance
 		expectBothStoreCalls actionInstance, dispatcher.waitFor
 
+	it 'should be able to handle finalizer errors gracefully', () ->
+		throwError = true
+		totalCalls = 0
+		error = new Error("My magical test error")
+
+		dispatcher.onFinalize () ->
+			totalCalls++
+			return unless throwError
+			throwError = false
+			throw error
+
+		actionInstance = actionCreator.createActionInstance(action, payload)
+		expect(dispatcher.dispatch.bind(dispatcher, actionInstance)).to.throw(error)
+
+		actionInstance = actionCreator.createActionInstance(action, payload)
+		dispatcher.dispatch actionInstance
+		expect(totalCalls).to.equal 2
+
 	it 'should wait for stores registered earlier', () ->
 
 		dispatcher.register storeA

--- a/test/event-broker.coffee
+++ b/test/event-broker.coffee
@@ -1,0 +1,171 @@
+Action        = require '../src/action'
+ActionCreator = require '../src/action-creator'
+{expect}      = require 'chai'
+
+describe 'EventBroker', () ->
+
+	EventBroker = null
+	dispatcher = null
+	action = null
+	actionCreator = null
+	payload = null
+
+	beforeEach () ->
+		if require.cache[require.resolve('../src/dispatcher')]
+			delete require.cache[require.resolve('../src/dispatcher')]
+			delete require.cache[require.resolve('../src/event-broker')]
+		dispatcher = require('../src/dispatcher')
+		EventBroker = require '../src/event-broker'
+		action = new Action("test-action")
+		actionCreator = new ActionCreator
+		payload = {test: true}
+
+	it 'should be able to handle listeners being removed while dispatching - removing listener before it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+			broker.remove secondHandler, ctx
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+
+		broker.add firstHandler, ctx
+		broker.add secondHandler, ctx
+
+		broker.dispatch()
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.false
+
+	it 'should be able to handle listeners being removed while dispatching - removing listener after it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+			broker.remove firstHandler, ctx
+
+		broker.add firstHandler, ctx
+		broker.add secondHandler, ctx
+
+		broker.dispatch()
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.true
+
+	it 'should be able to handle listeners being removed while dispatching immediate - removing listener before it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+			broker.removeImmediate secondHandler, ctx
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+
+		broker.addImmediate firstHandler, ctx
+		broker.addImmediate secondHandler, ctx
+
+		broker.dispatch()
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.false
+
+	it 'should be able to handle listeners being removed while dispatching immediate - removing listener after it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+			broker.removeImmediate firstHandler, ctx
+
+		broker.addImmediate firstHandler, ctx
+		broker.addImmediate secondHandler, ctx
+
+		broker.dispatch()
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.true
+
+	it 'should be able to handle listeners being removed while dispatcher is dispatching - removing listener before it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+			broker.remove secondHandler, ctx
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+
+		broker.add firstHandler, ctx
+		broker.add secondHandler, ctx
+
+		dispatcher.register {
+			_handleAction: () ->
+				expect(dispatcher.isDispatching()).to.be.true
+				broker.dispatch()
+				expect(firstHandlerCalled).to.equal false, "First handler"
+				expect(secondHandlerCalled).to.equal false, "Second handler"
+		}
+
+		actionInstance = actionCreator.createActionInstance(action, payload)
+		dispatcher.dispatch actionInstance
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.false
+
+	it 'should be able to handle listeners being removed while dispatcher is dispatching - removing listener after it has been dispatched', () ->
+		broker = EventBroker()
+		ctx = {}
+
+		firstHandlerCalled = false
+		secondHandlerCalled = false
+
+		firstHandler = () ->
+			firstHandlerCalled = true
+
+		secondHandler = () ->
+			secondHandlerCalled = true
+			broker.remove firstHandler, ctx
+
+		broker.add firstHandler, ctx
+		broker.add secondHandler, ctx
+
+		dispatcher.register {
+			_handleAction: () ->
+				expect(dispatcher.isDispatching()).to.be.true
+				broker.dispatch()
+				expect(firstHandlerCalled).to.equal false, "First handler"
+				expect(secondHandlerCalled).to.equal false, "Second handler"
+		}
+
+		actionInstance = actionCreator.createActionInstance(action, payload)
+		dispatcher.dispatch actionInstance
+
+		expect(firstHandlerCalled).to.be.true
+		expect(secondHandlerCalled).to.be.true


### PR DESCRIPTION
This fixes 2 different things:
- Enable the event broker to handle listeners of various kinds being removed while dispatching.
- Enable the dispatcher to handle errors gracefully during the finalizer phase.
